### PR TITLE
Add support for styled inline text (bold, italic, underline, strikethrough) in bullets and paragraphs.

### DIFF
--- a/app/slide.py
+++ b/app/slide.py
@@ -66,19 +66,32 @@ class ParagraphContent(SlideContent):
     """
     Represents a plain paragraph block.
     """
-    def __init__(self, text):
-        self.text = text
+    def __init__(self, runs):
+        self.runs = runs
 
     def to_html(self):
-        return f"  <p class='fragment'>{self.text}</p>"
+        html = "  <p class='fragment'>"
+        for run in self.runs:
+            text = run["text"]
+            if run.get("bold"):
+                text = f"<strong>{text}</strong>"
+            if run.get("italic"):
+                text = f"<em>{text}</em>"
+            if run.get("underline"):
+                text = f"<u>{text}</u>"
+            if run.get("strikethrough"):
+                text = f"<span style='text-decoration: line-through;'>{text}</span>"
+            html += text
+        html += "</p>"
+        return html
 
 
 class BulletNode(SlideContent):
     """
     Represents a bullet point.
     """
-    def __init__(self, text, level, ordered=False):
-        self.text = text
+    def __init__(self, runs, level, ordered=False):
+        self.runs = runs
         self.level = level
         self.ordered = ordered
         self.children = []
@@ -87,7 +100,19 @@ class BulletNode(SlideContent):
         self.children.append(node)
 
     def to_html(self):
-        html = f"<li class='fragment'>{self.text}"
+        html = "<li class='fragment'>"
+        for run in self.runs:
+            text = run["text"]
+            if run.get("bold"):
+                text = f"<strong>{text}</strong>"
+            if run.get("italic"):
+                text = f"<em>{text}</em>"
+            if run.get("underline"):
+                text = f"<u>{text}</u>"
+            if run.get("strikethrough"):
+                text = f"<span style='text-decoration: line-through;'>{text}</span>"
+            html += text
+            
         if self.children:
             tag = "ol" if self.ordered else "ul"
             html += f"<{tag}>"


### PR DESCRIPTION
feat: Add support for styled inline text (bold, italic, underline, strikethrough) in bullets and paragraphs

- Updated xml_parser.py to extract <a:r> text runs from <a:p> and preserve formatting:
  - Supports detection of bold (b="1"), italic (i="1"), underline (u="sng"/"dbl"), and strikethrough (strike="sng"/"dbl")
  - Added 'runs' list to each text shape alongside the existing 'text' string for backward compatibility
- Updated converter.py to:
  - Pass 'runs' to ParagraphContent and BulletNode instead of plain text
  - Handle only supported types explicitly (text and table), ignore unknowns safely
- Updated slide.py to:
  - Render inline HTML using <strong>, <em>, <u>, and <span style='text-decoration:line-through'>
  - Preserve paragraph and bullet structure while allowing rich inline formatting
- Improved future extensibility by checking item["type"] explicitly instead of assuming fallback behavior
